### PR TITLE
fix options not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.2.2
+- fixed important bug : -b/-c options not working
+
 # v0.2.1
 - fixed important bug : -b/-c options not working
 - added a CHANGELOG file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "linux-on-drugs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linux-on-drugs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
    while args.len() > 0 {
       match args[0].as_str() {
          "-c" | "--content" => {
-            if ! args.len() > 1 {
+            if args.len() < 2 {
                // if no argument is provided after the flag
                // print an error message and exit
                println!(
@@ -75,7 +75,7 @@ fn main() {
             }
          }
          "-b" | "--block-size" => {
-            if ! args.len() > 1 {
+            if args.len() < 2 {
                println!(
                   "{}[ x ] : Error: Argument needed after -b/--block-size{}",
                   RED, RESET
@@ -140,8 +140,16 @@ fn main() {
          println!("{}━━━━━━━━━━━━━━━━━{}", MAGENTA, RESET);
          drug_print("Gives drugs to your computer.");
          println!("{}━━━━━━━━━━━━━━━━━{}", MAGENTA, RESET);
-         println!("{}The readme contains a lot of informations {}", MAGENTA, RESET);
-         println!("{}https://github.com/SkwalExe/{}{}", MAGENTA, env!("CARGO_PKG_NAME"),  RESET);
+         println!(
+            "{}The readme contains a lot of informations {}",
+            MAGENTA, RESET
+         );
+         println!(
+            "{}https://github.com/SkwalExe/{}{}",
+            MAGENTA,
+            env!("CARGO_PKG_NAME"),
+            RESET
+         );
          println!("{}━━━━━━━━━━━━━━━━━{}", MAGENTA, RESET);
          println!("Options : ");
          println!(


### PR DESCRIPTION
closes #6 

I replaced

```rust
if args.len() > 1 {
               println!(
                  "{}[ x ] : Error: Argument needed after -b/--block-size{}",
                  RED, RESET
               );
               process::exit(1);
}
```

`args.len() > 1` by `!args.len() > 1` but the `!` operator doesn't seem to work (?) it always return true.

so I replaced by `< 2`